### PR TITLE
tyranny gain search option

### DIFF
--- a/common/scripted_triggers/at_artifact_modifier_triggers.txt
+++ b/common/scripted_triggers/at_artifact_modifier_triggers.txt
@@ -118,6 +118,7 @@ at_has_artifact_dynasty_prestige_modifier = {
 
 at_has_artifact_tyranny_modifier = {
 	OR = {
+		# Reduction
 		has_artifact_modifier = artifact_monthly_tyranny_1_modifier
 		has_artifact_modifier = artifact_monthly_tyranny_2_modifier
 		has_artifact_modifier = artifact_monthly_tyranny_3_modifier
@@ -126,8 +127,8 @@ at_has_artifact_tyranny_modifier = {
 		has_artifact_modifier = artifact_monthly_tyranny_6_modifier
 		has_artifact_modifier = artifact_monthly_tyranny_7_modifier
 		has_artifact_modifier = artifact_monthly_tyranny_8_modifier
+		# Gain
 		has_artifact_modifier = artifact_tyranny_gain_mult_1_modifier
-		# Negative
 		has_artifact_modifier = artifact_propaganda_chronicle_modifier
 		has_artifact_modifier = jewelled_danda_modifier
 		has_artifact_modifier = Shamshir-e_Zomorrodnegar_modifier

--- a/common/scripted_triggers/at_artifact_modifier_triggers.txt
+++ b/common/scripted_triggers/at_artifact_modifier_triggers.txt
@@ -126,8 +126,11 @@ at_has_artifact_tyranny_modifier = {
 		has_artifact_modifier = artifact_monthly_tyranny_6_modifier
 		has_artifact_modifier = artifact_monthly_tyranny_7_modifier
 		has_artifact_modifier = artifact_monthly_tyranny_8_modifier
-		# Negative
 		has_artifact_modifier = artifact_tyranny_gain_mult_1_modifier
+		# Negative
+		has_artifact_modifier = artifact_propaganda_chronicle_modifier
+		has_artifact_modifier = jewelled_danda_modifier
+		has_artifact_modifier = Shamshir-e_Zomorrodnegar_modifier
 	}
 }
 


### PR DESCRIPTION
at_modifier->"at_tyranny" search option only shows the "tyranny gain +10%" and "tyranny reduction" modifier.
The option to search for negative modifiers seems to be missing.
(example. Jeweled Danda: -20% Tyranny Gain)